### PR TITLE
Fix in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp-strip-debug": "^1.1.0",
     "gulp-uglify": "^1.5.2",
     "three": "^0.78.0",
-    "tween.js": "^16.3.5"
+    "tween.js": "^16.3.5",
     "iphone-inline-video": "^1.9.3"
   }
 }


### PR DESCRIPTION
I've got the following error because there was a typo in package.json

```
npm ERR! Cloning into bare repository '/Users/martijn/.npm/_git-remotes/git-github-com-pchen66-panolens-js-git-dev-c0fa4167'...
npm ERR! Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
```

This commit fixes the issue 👍 