### PR TITLE
Better offset when setting raycasterPoint X and Y

### DIFF
--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -1285,10 +1285,10 @@
 
 	PANOLENS.Viewer.prototype.onTap = function ( event, type ) {
 
-		var intersects, intersect_entity, intersect;
+		var bounding = this.container.getBoundingClientRect(), intersects, intersect_entity, intersect;
 
-		this.raycasterPoint.x = ( ( event.clientX - this.container.offsetLeft ) / this.container.clientWidth ) * 2 - 1;
-		this.raycasterPoint.y = - ( ( event.clientY - this.container.offsetTop ) / this.container.clientHeight ) * 2 + 1;
+		this.raycasterPoint.x = ( ( event.clientX - bounding.left ) / this.container.clientWidth ) * 2 - 1;
+		this.raycasterPoint.y = - ( ( event.clientY - bounding.top ) / this.container.clientHeight ) * 2 + 1;
 
 		this.raycaster.setFromCamera( this.raycasterPoint, this.camera );
 


### PR DESCRIPTION
Infospot hover detection was incorrect when PANOLENS was used on scrolling pages, or when it was offset from the side / top of the page. This fix should allow the X and Y values to be accurately placed when the canvas is offset, even if positioned inside a relative element.