### PR TITLE
Fixing infospots so that if animation is disabled in constructor the …

### DIFF
--- a/src/infospot/Infospot.js
+++ b/src/infospot/Infospot.js
@@ -518,7 +518,9 @@
 			this.showAnimation && this.showAnimation.delay( delay ).start();
 
 		}
-
+		else{
+			this.opacity = 1;
+		}
 	};
 
 	/**
@@ -535,7 +537,9 @@
 			this.hideAnimation && this.hideAnimation.delay( delay ).start();
 
 		}
-		
+		else{
+			this.opacity = 0;
+		}
 		
 	};
 


### PR DESCRIPTION
The infospot constructor has a 2nd parameter for disabling animation. Currently if you do disable it then the infospot never displays because the show and hide methods do nothing if animation is disabled.