### PR TITLE
fix: didn't hide infospot when change panorama

### DIFF
--- a/src/infospot/Infospot.js
+++ b/src/infospot/Infospot.js
@@ -602,7 +602,12 @@ Infospot.prototype = Object.assign( Object.create( THREE.Sprite.prototype ), {
      */
     hide: function ( delay = 0 ) {
 
-        const { animated, hideAnimation, showAnimation, material } = this;
+        const { animated, hideAnimation, showAnimation, material, element } = this;
+
+        if ( element ) {
+          const { style } = element;
+          style.display = 'none';
+        }
 
         if ( animated ) {
 

--- a/src/infospot/Infospot.js
+++ b/src/infospot/Infospot.js
@@ -605,8 +605,8 @@ Infospot.prototype = Object.assign( Object.create( THREE.Sprite.prototype ), {
         const { animated, hideAnimation, showAnimation, material, element } = this;
 
         if ( element ) {
-          const { style } = element;
-          style.display = 'none';
+            const { style } = element;
+            style.display = 'none';
         }
 
         if ( animated ) {


### PR DESCRIPTION
Hi. I got some bugs. When changing PanoramaImage. Some infospot didn't hide the text. I have fixed it. Please take a look. 