### PR TITLE
Fix panorama error event

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -79,6 +79,11 @@ const ImageLoader = {
 	
         request = new window.XMLHttpRequest();
         request.open( 'GET', url, true );
+        request.onreadystatechange = function () {
+            if (this.readyState == 4 && this.status >= 400) {
+                onError();
+            }
+        };
         request.responseType = 'arraybuffer';
         request.addEventListener( 'error', onError );
         request.addEventListener( 'progress', event => {


### PR DESCRIPTION
Hello @pchen66 ,

Currently the error event isn't dispatch during the ajax request.
I don't know if my fix cover all the cases but it works as expected now.