### PR TITLE
Fixes a caching problem in the ImageLoader (see #263)

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -41,12 +41,21 @@ const ImageLoader = {
 
             if (onLoad) {
 
-                setTimeout(function () {
+                if ( cached.complete && cached.src ) {
+                    setTimeout( function () {
 
-                    onProgress({loaded: 1, total: 1});
-                    onLoad(cached);
+                        onProgress( { loaded: 1, total: 1 } );
+                        onLoad( cached );
 
-                }, 0);
+                    }, 0 );
+                } else {
+                    cached.addEventListener( 'load', function () {
+
+                        onProgress( { loaded: 1, total: 1 } );
+                        onLoad( cached );
+
+                    }, false );
+                }
 
             }
 


### PR DESCRIPTION
This should fix #263: The ImageLoader uses a cache and if he finds an image in the cache he doesn't check if it is already completely loaded. But if the image is not completely loaded the width and height is 0 and the rate is NaN and the Infospot will not be rendered correctly.

This is not a problem for images that are only used once, since the cache is not used for those.