### PR TITLE
check exist of variable "process" before use it

### DIFF
--- a/src/loaders/ImageLoader.js
+++ b/src/loaders/ImageLoader.js
@@ -88,7 +88,10 @@ const ImageLoader = {
 
         request = new window.XMLHttpRequest();
         request.open('GET', url, true);
-        if (process.env.npm_lifecycle_event !== 'test') {
+        if (
+		typeof process === 'object' &&
+		process.env.npm_lifecycle_event !== 'test'
+	) {
             /* istanbul ignore next */
             request.onreadystatechange = function () {
                 if (this.readyState === 4 && this.status >= 400) {


### PR DESCRIPTION
prevent "process is not defined" error in web browser, some building tools may not inject process in window object