### PR TITLE
Fix multiple CubePanorama, same opacity issue

### DIFF
--- a/src/panorama/CubePanorama.js
+++ b/src/panorama/CubePanorama.js
@@ -16,7 +16,7 @@ function CubePanorama ( images = [] ){
 
         fragmentShader: shader.fragmentShader,
         vertexShader: shader.vertexShader,
-        uniforms: shader.uniforms,
+        uniforms: { ...shader.uniforms, opacity:{ ...shader.uniforms.opacity }},
         side: THREE.BackSide,
         transparent: true
 


### PR DESCRIPTION
When the `uniform` object isn't deep cloned, multiple `CubePanorama` objects have the same `material.uniforms.opacity` object. This causes an issue if they're linked. After the transition is complete, the first cube's `opacity` turns `false` and since they're identical, the new one's also do. So the user ends up with a black screen. The `THREE.ShaderLib[ 'cube' ]` probably needs to be deep cloned but I wanted to make the minimum amount of changes to fix the issue.