### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Panolens.js is an event-driven and WebGL based panorama viewer. Lightweight and 
 
 Include `three.min.js` and `panolens.min.js`
 
-To find the correct supported versions, please check `dependencies` section in `package.json` or acess `PANOLENS.VERSION` or `PANOLENS.THREE_VERSION` at runtime.
+To find the correct supported versions, please check `dependencies` section in `package.json` or access `PANOLENS.VERSION` or `PANOLENS.THREE_VERSION` at runtime.
 
 ```html
 <script src="js/three.min.js"></script>

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -356,7 +356,7 @@ Viewer.prototype = Object.assign( Object.create( THREE.EventDispatcher.prototype
 
         if ( pano.type === 'panorama' && leavingPanorama !== pano ) {
 
-            // Clear exisiting infospot
+            // Clear existing infospot
             this.hideInfospot();
 
             const afterEnterComplete = function () {
@@ -900,7 +900,7 @@ Viewer.prototype = Object.assign( Object.create( THREE.EventDispatcher.prototype
      * Get container
      * @memberOf Viewer
      * @instance
-     * @return {HTMLElement} - The container holds rendererd canvas
+     * @return {HTMLElement} - The container holds rendered canvas
      */
     getContainer: function () {
 

--- a/src/widget/Widget.js
+++ b/src/widget/Widget.js
@@ -467,7 +467,7 @@ Widget.prototype = Object.assign( Object.create( THREE.EventDispatcher.prototype
 
         } );
 
-        // Add fullscreen stlye if not exists
+        // Add fullscreen style if not exists
         if ( !document.querySelector( stylesheetId ) ) {
             const sheet = document.createElement( 'style' );
             sheet.id = stylesheetId;


### PR DESCRIPTION
There are small typos in:
- README.md
- src/viewer/Viewer.js
- src/widget/Widget.js

Fixes:
- Should read `style` rather than `stlye`.
- Should read `existing` rather than `exisiting`.
- Should read `rendered` rather than `rendererd`.
- Should read `access` rather than `acess`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md